### PR TITLE
Block a wider range of ads, tracking scripts, and unwanted content from various domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -125,22 +125,69 @@ chrome.runtime.onInstalled.addListener(() => {
                 id: 21,
                 priority: 1,
                 action: { type: 'block' },
-                condition: { urlFilter: '*://*.youtube.com/get_video_info*', resourceTypes: ['script', 'xmlhttprequest'] }
+                condition: { urlFilter: 'adform.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
             },
             {
                 id: 22,
                 priority: 1,
                 action: { type: 'block' },
-                condition: { urlFilter: '*://*.youtube.com/watch*', resourceTypes: ['media'] }
+                condition: { urlFilter: 'openx.net', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
             },
             {
                 id: 23,
                 priority: 1,
                 action: { type: 'block' },
-                condition: { urlFilter: '*://*.googleads.g.doubleclick.net/*', resourceTypes: ['script', 'xmlhttprequest'] }
+                condition: { urlFilter: 'google-analytics.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 24,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'googletagmanager.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 25,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'quantserve.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 26,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'media.net', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 27,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'sentry.io', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 28,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'logrocket.io', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 29,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'hotjar.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 30,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'mc.yandex.ru', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 31,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'bugsnag.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
             }
-            // You can continue adding more blocking rules here...
         ],
-        removeRuleIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,21,22,23] 
+        removeRuleIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
     });
 });


### PR DESCRIPTION
I have used this [site](https://adblock-tester.com/) to test whether the changes I have made have improved the overall efficiency of the ad-blocking. Initially without using BlockHub the efficient of my chrome browser was 37%. 
<img width="1470" alt="Screenshot 2024-09-26 at 00 00 33" src="https://github.com/user-attachments/assets/2f550e2e-1222-42f1-851f-4059f2acfa73">
After using BlockHub with the current domain restrictions it is 45%.
<img width="1470" alt="Screenshot 2024-09-26 at 00 00 03" src="https://github.com/user-attachments/assets/3a94de6d-77d3-41dd-a186-41d20f204de6">
After the additions I have made it is 84%.
<img width="1470" alt="Screenshot 2024-09-25 at 23 40 56" src="https://github.com/user-attachments/assets/1b87a250-21a6-4a45-97eb-d9c3f5d29b9f">