### PR TITLE
add more blocking rules

### DIFF
--- a/background.js
+++ b/background.js
@@ -139,8 +139,99 @@ chrome.runtime.onInstalled.addListener(() => {
                 action: { type: 'block' },
                 condition: { urlFilter: '*://*.googleads.g.doubleclick.net/*', resourceTypes: ['script', 'xmlhttprequest'] }
             }
+            {
+                id: 24,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'bounceexchange.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 25,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'quantserve.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 26,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'openx.net', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 27,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'gumgum.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 28,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'teads.tv', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 29,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'media.net', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 30,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'tapad.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 31,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'exelator.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 32,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'rubiconproject.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 33,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'cdn.taboola.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 34,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'contextweb.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 35,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'spotxchange.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 36,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'outbrain.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 37,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'adroll.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            },
+            {
+                id: 38,
+                priority: 1,
+                action: { type: 'block' },
+                condition: { urlFilter: 'revcontent.com', resourceTypes: ['script', 'image', 'xmlhttprequest'] }
+            }
+
             // You can continue adding more blocking rules here...
         ],
-        removeRuleIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,21,22,23] 
+        removeRuleIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38] 
     });
 });


### PR DESCRIPTION
This PR adds several new dynamic blocking rules to enhance the functionality of the Chrome extension. The newly added rules target more ad networks and trackers to improve user privacy, reduce unwanted advertisements, and boost page load times by preventing requests from these domains.

### Added new blocking rules for additional ad networks and tracking domains:

- bounceexchange.com
- quantserve.com
- openx.net
- gumgum.com
- teads.tv
- media.net
- tapad.com
- exelator.com
- rubiconproject.com
- cdn.taboola.com
- contextweb.com
- spotxchange.com
- adroll.com